### PR TITLE
Remove unused step ids from publish-git-tags workflow

### DIFF
--- a/.github/workflows/publish-git-tags.yaml
+++ b/.github/workflows/publish-git-tags.yaml
@@ -24,7 +24,6 @@ jobs:
           token: ${{ secrets.DEPLOY_TOKEN }}
 
       - name: Login for bot
-        id: login
         run: |
           git config --global user.email "$secrets.TURPLANLEGGER_BOT_EMAIL"
           git config --global user.name "Turplanlegger Bot"
@@ -38,11 +37,9 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Get repo version
-        id: new_tag
         run: echo "NEW_VERSION=$(cat turplanlegger/__about__.py | cut -d'=' -f2 | xargs)" >> $GITHUB_ENV
 
       - name: Check if tag exists and and fail if it does
-        id: new_sha
         run: |
           if git rev-parse -q --verify $NEW_VERSION; then
             echo "Tag \`$NEW_VERSION\` exists, will not create new" >> $GITHUB_STEP_SUMMARY;
@@ -53,21 +50,18 @@ jobs:
           fi
 
       - name: Create new tag
-        id: create_tag
         run: |
           git tag -sam "Release v$NEW_VERSION" $NEW_VERSION
           git push --tags
           echo "Tag \`$NEW_VERSION\` \`$(git rev-parse -q --verify $NEW_VERSION)\` created" >> $GITHUB_STEP_SUMMARY
 
       - name: Update latest tag
-        id: update_latest
         run: |
           git tag -sfam "Release v$NEW_VERSION" latest
           git push --force --tags
           echo "Tag \`latest\` updated to \`$NEW_VERSION\` \`$(git rev-parse -q --verify $NEW_VERSION)\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Create GitHub Release
-        id: create_release
         uses: ncipollo/release-action@v1
         with:
           name: "Release ${{ env.NEW_VERSION }}"


### PR DESCRIPTION
Removing them will simplify each step and improve readability.