### PR TITLE
Remove unused environment variables from publish-git-tags workflow

### DIFF
--- a/.github/workflows/publish-git-tags.yaml
+++ b/.github/workflows/publish-git-tags.yaml
@@ -5,10 +5,6 @@ on:
   push:
     branches: [main]
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   check-and-publish-new-tags:
     runs-on: ubuntu-latest


### PR DESCRIPTION
These are never used in this workflow.