### PR TITLE
Only run publish-git-tags workflow when version file is updated

### DIFF
--- a/.github/workflows/publish-git-tags.yaml
+++ b/.github/workflows/publish-git-tags.yaml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Create new tag
         run: |
-          git tag -sam "Release v$NEW_VERSION" $NEW_VERSION
-          git push --tags
+          git tag -sam "Release v$NEW_VERSION" "$NEW_VERSION"
+          git push origin "$NEW_VERSION"
           echo "Tag \`$NEW_VERSION\` \`$(git rev-parse -q --verify $NEW_VERSION)\` created" >> $GITHUB_STEP_SUMMARY
 
       - name: Update latest tag

--- a/.github/workflows/publish-git-tags.yaml
+++ b/.github/workflows/publish-git-tags.yaml
@@ -8,7 +8,7 @@ on:
       - turplanlegger/__about__.py
 
 jobs:
-  check-and-publish-new-tags:
+  publish-new-tag:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,18 +34,8 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Get repo version
-        run: echo "NEW_VERSION=$(cat turplanlegger/__about__.py | cut -d'=' -f2 | xargs)" >> $GITHUB_ENV
-
-      - name: Check if tag exists and and fail if it does
-        run: |
-          if git rev-parse -q --verify $NEW_VERSION; then
-            echo "Tag \`$NEW_VERSION\` exists, will not create new" >> $GITHUB_STEP_SUMMARY;
-            exit 1
-          else
-            echo "Tag \`$NEW_VERSION\` does not exists, will create new tag" >> $GITHUB_STEP_SUMMARY
-            exit 0
-          fi
+      - name: Get version
+        run: echo "NEW_VERSION=$(cat turplanlegger/__about__.py | cut -d'=' -f2 | xargs)" >> "$GITHUB_ENV"
 
       - name: Create new tag
         run: |

--- a/.github/workflows/publish-git-tags.yaml
+++ b/.github/workflows/publish-git-tags.yaml
@@ -35,7 +35,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Get version
-        run: echo "NEW_VERSION=$(cat turplanlegger/__about__.py | cut -d'=' -f2 | xargs)" >> "$GITHUB_ENV"
+        run: echo "NEW_VERSION=$(grep -v '^#' turplanlegger/__about__.py | cut -d'=' -f2 | xargs)" >> "$GITHUB_ENV"
 
       - name: Create new tag
         run: |

--- a/.github/workflows/publish-git-tags.yaml
+++ b/.github/workflows/publish-git-tags.yaml
@@ -1,9 +1,11 @@
 name: Create and publish a Github tag and release
 
 on:
-  workflow_dispatch:
   push:
-    branches: [main]
+    branches:
+      - main
+    paths:
+      - turplanlegger/__about__.py
 
 jobs:
   check-and-publish-new-tags:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ git commit tests/test_result.csv -m "Unitetest result"
 
 ## Building and publishing.
 Editing the [__about__.py](turplanlegger/__about__.py) file will trigger a GitHub Action that creates a new version tag.  
-After a new version tag is avaiable on GitHub, the new version will be build by GitHub Actions and a new release is published.
+After a new version tag is avaiable on GitHub, the new version will be built by GitHub Actions and a new release is published.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ pytest tests/test_*.py --csv tests/test_result.csv --csv-columns utc_timestamp,i
 git commit tests/test_result.csv -m "Unitetest result"
 ```
 
+## Building and publishing.
+Editing the [__about__.py](turplanlegger/__about__.py) file will trigger a GitHub Action that creates a new version tag.  
+After a new version tag is avaiable on GitHub, the new version will be build by GitHub Actions and a new release is published.
 
 ## Docker
 

--- a/turplanlegger/__about__.py
+++ b/turplanlegger/__about__.py
@@ -1,1 +1,3 @@
+# Editing this file on the main branch will trigger a GitHub Action that creates a new version tag.
+# After a new version tag is avaiable on GitHub, the new version will be build and published
 __version__ = '0.0.9b1'

--- a/turplanlegger/__about__.py
+++ b/turplanlegger/__about__.py
@@ -1,3 +1,3 @@
 # Editing this file on the main branch will trigger a GitHub Action that creates a new version tag.
-# After a new version tag is avaiable on GitHub, the new version will be build and published
+# After a new version tag is avaiable on GitHub, the new version will be built and published
 __version__ = '0.0.9b1'


### PR DESCRIPTION
This workflow does not need to run every time the main branch is updated, so now it will only start when changes are made to the `turplanlegger/__about__.py` file.
With some additional improvements as well, see commit messages for more information.

Creating a tag that already exists (https://github.com/Turplanlegger/turplanlegger-api/pull/168/commits/ac4f1fdbf7a480ed83d241d015f8e4098425847b) was tested in [this](https://github.com/Turplanlegger/turplanlegger-api/actions/runs/6254320283/job/16981595170) workflow run and works as expected.