### PR TITLE
Remove unused pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,6 @@ repos:
         args: ['--remove']
     -   id: name-tests-test
         args: ['--django']
-    -   id: trailing-whitespace
-        args: [--markdown-linebreak-ext=md]
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: 'v0.1.3'
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     -   id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.0.269'
+  rev: 'v0.1.3'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,6 @@ repos:
     -   id: end-of-file-fixer
     -   id: fix-encoding-pragma
         args: ['--remove']
-    -   id: pretty-format-json
-        args: ['--autofix']
     -   id: name-tests-test
         args: ['--django']
     -   id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,6 @@ repos:
         args: ['--autofix']
     -   id: name-tests-test
         args: ['--django']
-    -   id: requirements-txt-fixer
     -   id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
 - repo: https://github.com/charliermarsh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
     -   id: double-quote-string-fixer
-    -   id: end-of-file-fixer
     -   id: fix-encoding-pragma
         args: ['--remove']
     -   id: name-tests-test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
     -   id: fix-byte-order-marker
     -   id: check-case-conflict
     -   id: check-docstring-first
-    -   id: check-json
     -   id: check-merge-conflict
     -   id: check-yaml
     -   id: debug-statements


### PR DESCRIPTION
This PR aims to clean up the pre-commit config and remove pre-commit hooks that are covered by ruff

Changes:
- Updated ruff hook

Removes:
- requirements.txt hook
- pretty-format-json hook
- check-json hook
- trailing-whitespace hook
- enf-of-file-fixer hook