### PR TITLE
ci(publish-git-tags): use turplanlegger-bot github app instead of user

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -20,12 +20,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.TURPLANLEGGER_BOT_APP_ID }}
+          private-key: ${{ secrets.TURPLANLEGGER_BOT_PRIVATE_KEY }}
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: turplanlegger-bot
-          password: ${{ secrets.DEPLOY_TOKEN }}
+          username: ${{ vars.TURPLANLEGGER_BOT_APP_ID }}
+          password: ${{ steps.app-token.outputs.token }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/publish-git-tags.yaml
+++ b/.github/workflows/publish-git-tags.yaml
@@ -13,13 +13,20 @@ jobs:
     permissions:
       contents: read
       packages: write
-
     steps:
+
+      - name: Get App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.TURPLANLEGGER_BOT_APP_ID }}
+          private-key: ${{ secrets.TURPLANLEGGER_BOT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.DEPLOY_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Login for bot
         run: |
@@ -50,8 +57,9 @@ jobs:
           echo "Tag \`latest\` updated to \`$NEW_VERSION\` \`$(git rev-parse -q --verify $NEW_VERSION)\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          name: "Release ${{ env.NEW_VERSION }}"
-          tag: ${{ env.NEW_VERSION }}
-          token: ${{ secrets.DEPLOY_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh release create "${{ env.NEW_VERSION }}" \
+            --title "Release ${{ env.NEW_VERSION }}" \
+            --latest

--- a/turplanlegger/__about__.py
+++ b/turplanlegger/__about__.py
@@ -1,3 +1,3 @@
 # Editing this file on the main branch will trigger a GitHub Action that creates a new version tag.
 # After a new version tag is avaiable on GitHub, the new version will be built and published
-__version__ = '0.0.11b1'
+__version__ = '0.0.11b2'


### PR DESCRIPTION
This pull request includes changes related to the GitHub Actions workflows and versioning of the codebase. The most important changes include adding a new step in the workflow to generate an app token for authentication with the container registry and updating the GitHub Actions workflow to use the "gh" command-line tool for creating releases.

Main workflow and authentication changes:

* [`.github/workflows/publish-docker-image.yaml`](diffhunk://#diff-ac9bda107c3925408bf0ffb31e643a4d1e8b9953abc242d8fdd4b32b0a68263aR23-R35): Added a new step in the workflow to generate an app token and use it for authentication with the container registry.
* [`.github/workflows/publish-git-tags.yaml`](diffhunk://#diff-66fcaee92797cb4d0415e38d5032ba4af796b303a522d3d5e7f37afe9a80d6d3L53-R65): Updated the GitHub Actions workflow to use the "gh" command-line tool for creating releases and added a new step to generate an app token for authentication with the repository. [[1]](diffhunk://#diff-66fcaee92797cb4d0415e38d5032ba4af796b303a522d3d5e7f37afe9a80d6d3L53-R65) [[2]](diffhunk://#diff-66fcaee92797cb4d0415e38d5032ba4af796b303a522d3d5e7f37afe9a80d6d3L16-R29)

Versioning changes:

* [`turplanlegger/__about__.py`](diffhunk://#diff-2e61069266152ba95cf828b5a92ed44f1eeee9310d7c5b4eff885644b2bee7a5L3-R3): Updated the version number in the "__about__.py" file to trigger the build and publish process.

Created a bot named Turplanlegger Bot and installed it in the repository. Created a secret containing the GitHub App private key and a variable to store the app id.