### PR TITLE
ci(publish-git-tags): remove latest tag

### DIFF
--- a/.github/workflows/publish-git-tags.yaml
+++ b/.github/workflows/publish-git-tags.yaml
@@ -50,12 +50,6 @@ jobs:
           git push origin "$NEW_VERSION"
           echo "Tag \`$NEW_VERSION\` \`$(git rev-parse -q --verify $NEW_VERSION)\` created" >> $GITHUB_STEP_SUMMARY
 
-      - name: Update latest tag
-        run: |
-          git tag -sfam "Release v$NEW_VERSION" latest
-          git push --force --tags
-          echo "Tag \`latest\` updated to \`$NEW_VERSION\` \`$(git rev-parse -q --verify $NEW_VERSION)\`" >> $GITHUB_STEP_SUMMARY
-
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This pull request includes a change to the workflow configuration file that removes the step responsible for updating the `latest` tag in the GitHub repository.

Main change:

* [`.github/workflows/publish-git-tags.yaml`](diffhunk://#diff-66fcaee92797cb4d0415e38d5032ba4af796b303a522d3d5e7f37afe9a80d6d3L53-L58): Removed the step that updates the `latest` tag in the GitHub repository.

It is not in use and both GitHub Releases and Docker have their own latest annotations.