### PR TITLE
ci(publish-docker-image): use repository token for pushing container to the GitHub package repository

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -7,7 +7,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push-image:
@@ -15,31 +14,24 @@ jobs:
     permissions:
       contents: read
       packages: write
-
     steps:
+
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Get App Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.TURPLANLEGGER_BOT_APP_ID }}
-          private-key: ${{ secrets.TURPLANLEGGER_BOT_PRIVATE_KEY }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ vars.TURPLANLEGGER_BOT_APP_ID }}
-          password: ${{ steps.app-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           context: git
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
             type=raw,value=latest
             type=pep440,pattern={{version}}


### PR DESCRIPTION
This token should have access to the package repository without any further configuration.