### PR TITLE
Renamed config entry LOG_PATH and LOG_FILE to LOG_FILE_PATH

### DIFF
--- a/config_template.conf
+++ b/config_template.conf
@@ -5,7 +5,7 @@ DATABASE_MAX_RETRIES =
 
 
 # Logging
-LOG_FILE =
+LOG_FILE_PATH =
 LOG_LEVEL =
 
 # Misc

--- a/turplanlegger/utils/config.py
+++ b/turplanlegger/utils/config.py
@@ -52,8 +52,8 @@ class Config:
         self.config['LOG_LEVEL'] = self.conf_ent('LOG_LEVEL', str, 'INFO')
         self.config['LOG_TO_FILE'] = self.conf_ent('LOG_TO_FILE', bool, False)
         if self.config['LOG_TO_FILE']:
-            self.config['LOG_PATH'] = self.conf_ent(
-                'LOG_PATH',
+            self.config['LOG_FILE_PATH'] = self.conf_ent(
+                'LOG_FILE_PATH',
                 str,
                 '/var/log/turplanlegger.log'
             )

--- a/turplanlegger/utils/logger.py
+++ b/turplanlegger/utils/logger.py
@@ -24,7 +24,7 @@ class Logger:
         ]
 
         if app.config.get('LOG_TO_FILE'):
-            handlers.append(logging.FileHandler(app.config.get('LOG_FILE')))
+            handlers.append(logging.FileHandler(app.config.get('LOG_FILE_PATH')))
 
         logging.basicConfig(
             level=log_level,


### PR DESCRIPTION
This PR aims to fix the config entry for LOG_FILE.

Changed:
 - Config entry for `LOG_FILE` and `LOG_PATH` has been renamed to `LOG_FILE_PATH`