### PR TITLE
🐋 Remove obsolete version key from docker-compose files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   dev-api:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   api:
     image: ghcr.io/turplanlegger/turplanlegger-api:${TP_TAG:-latest}


### PR DESCRIPTION
This PR aims to remove the deprecation warning about version key obsolete.