### PR TITLE
:wrench: (workflows/release): Add id-token permission to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This is required to be able to use the Azure login action in the release workflow.