### PR TITLE
👽️ Replace utcnow with UTC

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -35,7 +35,7 @@ class UsersTestCase(unittest.TestCase):
             RETURNING *
         """
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
 
         faulty_vars = {
             'id': 1,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -35,7 +35,7 @@ class UsersTestCase(unittest.TestCase):
             RETURNING *
         """
 
-        now = datetime.datetime.now(datetime.UTC)
+        now = datetime.datetime.now()
 
         faulty_vars = {
             'id': 1,


### PR DESCRIPTION
This MR aims to fix deprecation error for `datetime.dateime.utcnow()`

![gone](https://media.tenor.com/TrAp6Sb0_PsAAAAm/they-are-gone-faisal-khan.webp "Gone")