### PR TITLE
🩹 Improve update trip functionality, support not passing trip dates

### DIFF
--- a/tests/test_trip.py
+++ b/tests/test_trip.py
@@ -582,15 +582,10 @@ class TripsTestCase(unittest.TestCase):
         response = self.client.post(
             '/trips', data=json.dumps(self.trip_with_multiple_dates_one_selected), headers=self.headers_json
         )
-
         self.assertEqual(response.status_code, 201)
-
         trip = json.loads(response.data.decode('utf-8'))
 
-        trip['name'] = 'New tripin pete'
-
-        response = self.client.put(f'/trips/{trip["id"]}', data=json.dumps(trip), headers=self.headers_json)
-
+        response = self.client.put(f'/trips/{trip["id"]}', data=json.dumps({'name': 'New tripin pete'}), headers=self.headers_json)
         self.assertEqual(response.status_code, 200)
 
         data = json.loads(response.data.decode('utf-8'))
@@ -598,7 +593,7 @@ class TripsTestCase(unittest.TestCase):
 
         self.assertEqual(data['id'], trip['id'])
         self.assertEqual(data['owner'], trip['owner'])
-        self.assertEqual(data['name'], trip['name'])
+        self.assertEqual(data['name'], 'New tripin pete')
 
         self.assertCountEqual(data['dates'], trip['dates'])
 

--- a/tests/test_trip.py
+++ b/tests/test_trip.py
@@ -585,7 +585,9 @@ class TripsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         trip = json.loads(response.data.decode('utf-8'))
 
-        response = self.client.put(f'/trips/{trip["id"]}', data=json.dumps({'name': 'New tripin pete'}), headers=self.headers_json)
+        response = self.client.put(
+            f'/trips/{trip["id"]}', data=json.dumps({'name': 'New tripin pete'}), headers=self.headers_json
+        )
         self.assertEqual(response.status_code, 200)
 
         data = json.loads(response.data.decode('utf-8'))

--- a/turplanlegger/views/trips.py
+++ b/turplanlegger/views/trips.py
@@ -49,10 +49,11 @@ def update_trip(trip_id):
 
     dates = request.json.get('dates', None)
 
-    date_status = Trip.update_trip_dates(dates, trip)
-    if date_status.changed is True:
-        trip_changed = True
-    errors.extend(date_status.errors)
+    if dates is not None:
+        date_status = Trip.update_trip_dates(dates, trip)
+        if date_status.changed is True:
+            trip_changed = True
+        errors.extend(date_status.errors)
 
     name = request.json.get('name', None)
     private = request.json.get('private', None)


### PR DESCRIPTION
Add support for updating trips and only passing the field to be updated.

![trippin](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExaGZscGl4aWtoMnA2bWM2OW44b2tsOWkwdGdkdTY4eTNyNThodWNyNyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/G2FTBp4wq9FqiJOoRQ/giphy.webp "Yes")