### PR TITLE
Permission/notes

### DIFF
--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -199,9 +199,13 @@ class NotesTestCase(unittest.TestCase):
         response = self.client.patch(
             '/notes/1/content', data=json.dumps({'content': 'newcontent'}), headers=self.headers_json
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 410)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['status'], 'ok')
+
+        self.assertEqual(data['title'], 'Endpoint has been deprecated')
+        self.assertEqual(data['detail'], 'Use PUT /notes/<note_id> instead')
+        self.assertEqual(data['type'], 'about:blank')
+        self.assertEqual(data['instance'], 'http://localhost/notes/1/content')
 
     def test_update_note(self):
         response = self.client.post('/notes', data=json.dumps(self.note_full), headers=self.headers_json)

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -212,9 +212,13 @@ class NotesTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
 
         response = self.client.patch('/notes/1/rename', data=json.dumps({'name': 'newlist'}), headers=self.headers_json)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 410)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['status'], 'ok')
+
+        self.assertEqual(data['title'], 'Endpoint has been deprecated')
+        self.assertEqual(data['detail'], 'Use PUT /notes/<note_id> instead')
+        self.assertEqual(data['type'], 'about:blank')
+        self.assertEqual(data['instance'], 'http://localhost/notes/1/rename')
 
     def test_update_note_content(self):
         response = self.client.post('/notes', data=json.dumps(self.note_full), headers=self.headers_json)

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -256,23 +256,6 @@ class NotesTestCase(unittest.TestCase):
         self.assertEqual(data['note']['name'], 'newname')
         self.assertEqual(data['note']['content'], 'newcontent')
 
-    def test_update_note_fail_no_change(self):
-        response = self.client.post('/notes', data=json.dumps(self.note_full), headers=self.headers_json)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.data.decode('utf-8'))
-        note_id = data['id']
-
-        response = self.client.put(
-            f'/notes/{note_id}',
-            data=json.dumps({'name': self.note_full['name'], 'content': self.note_full['content']}),
-            headers=self.headers_json,
-        )
-
-        self.assertEqual(response.status_code, 409)
-        data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['title'], 'Failed to update note')
-        self.assertEqual(data['detail'], 'No new updates were provided')
-
     def test_update_empty(self):
         response = self.client.post('/notes', data=json.dumps(self.note_full), headers=self.headers_json)
         self.assertEqual(response.status_code, 201)
@@ -304,21 +287,6 @@ class NotesTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['note']['name'], 'It now has a new name')
         self.assertEqual(data['note']['content'], self.note_full['content'])
-
-    def test_update_note_empty_content_update(self):
-        response = self.client.post('/notes', data=json.dumps(self.note_full), headers=self.headers_json)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.data.decode('utf-8'))
-        note_id = data['id']
-
-        response = self.client.put(
-            f'/notes/{note_id}', data=json.dumps({'name': self.note_full['name']}), headers=self.headers_json
-        )
-
-        self.assertEqual(response.status_code, 409)
-        data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['title'], 'Failed to update note')
-        self.assertEqual(data['detail'], 'Field content can not be empty')
 
     def test_update_name(self):
         response = self.client.post('/notes', data=json.dumps(self.note_full), headers=self.headers_json)

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -266,10 +266,10 @@ class NotesTestCase(unittest.TestCase):
             f'/notes/{note_id}', data=json.dumps({'name': None, 'content': None}), headers=self.headers_json
         )
 
-        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.status_code, 400)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['title'], 'Failed to update note')
-        self.assertEqual(data['detail'], 'Field content can not be empty')
+        self.assertEqual(data['title'], 'Failed to parse note update')
+        self.assertEqual(data['detail'], "Missing mandatory field 'content'")
 
     def test_update_content(self):
         response = self.client.post('/notes', data=json.dumps(self.note_full), headers=self.headers_json)

--- a/tests/test_note_permissions.py
+++ b/tests/test_note_permissions.py
@@ -1,5 +1,4 @@
 import json
-from pprint import pprint
 import unittest
 from uuid import uuid4
 
@@ -85,7 +84,6 @@ class NotesTestCase(unittest.TestCase):
                 },
             ],
         }
-
 
         # User 1
         response = cls.client.post(
@@ -187,7 +185,9 @@ class NotesTestCase(unittest.TestCase):
         note = json.loads(response.data.decode('utf-8'))
         note['content'] = 'Tripper'
         response = self.client.put(
-            f'/notes/{note["id"]}', data=json.dumps({'name': self.note_modify['name'], 'content': note.get('content')}), headers=self.headers_json_user1
+            f'/notes/{note["id"]}',
+            data=json.dumps({'name': self.note_modify['name'], 'content': note.get('content')}),
+            headers=self.headers_json_user1,
         )
 
         self.assertEqual(response.status_code, 200)
@@ -201,7 +201,9 @@ class NotesTestCase(unittest.TestCase):
 
         note['content'] = 'Tripper2'
         response = self.client.put(
-            f'/notes/{note["id"]}', data=json.dumps({'name': self.note_modify['name'], 'content': note.get('content')}), headers=self.headers_json_user2
+            f'/notes/{note["id"]}',
+            data=json.dumps({'name': self.note_modify['name'], 'content': note.get('content')}),
+            headers=self.headers_json_user2,
         )
 
         self.assertEqual(response.status_code, 200)
@@ -213,7 +215,9 @@ class NotesTestCase(unittest.TestCase):
 
         # User 3 - not ok
         response = self.client.put(
-            f'/notes/{note["id"]}', data=json.dumps({'name': self.note_modify['name'], 'content': 'poopy'}), headers=self.headers_json_user3
+            f'/notes/{note["id"]}',
+            data=json.dumps({'name': self.note_modify['name'], 'content': 'poopy'}),
+            headers=self.headers_json_user3,
         )
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(response.status_code, 404)
@@ -229,7 +233,9 @@ class NotesTestCase(unittest.TestCase):
         note = json.loads(response.data.decode('utf-8'))
         note['content'] = 'Tripper'
         response = self.client.put(
-            f'/notes/{note["id"]}', data=json.dumps({'name': self.note_read['name'], 'content': note.get('content')}), headers=self.headers_json_user1
+            f'/notes/{note["id"]}',
+            data=json.dumps({'name': self.note_read['name'], 'content': note.get('content')}),
+            headers=self.headers_json_user1,
         )
 
         self.assertEqual(response.status_code, 200)
@@ -243,7 +249,9 @@ class NotesTestCase(unittest.TestCase):
 
         note['content'] = 'Tripper2'
         response = self.client.put(
-            f'/notes/{note["id"]}', data=json.dumps({'name': self.note_read['name'], 'content': note.get('content')}), headers=self.headers_json_user2
+            f'/notes/{note["id"]}',
+            data=json.dumps({'name': self.note_read['name'], 'content': note.get('content')}),
+            headers=self.headers_json_user2,
         )
 
         self.assertEqual(response.status_code, 403)
@@ -256,7 +264,9 @@ class NotesTestCase(unittest.TestCase):
 
         # User 3 - not ok
         response = self.client.put(
-            f'/notes/{note["id"]}', data=json.dumps({'name': self.note_read['name'], 'content': 'poopy'}), headers=self.headers_json_user3
+            f'/notes/{note["id"]}',
+            data=json.dumps({'name': self.note_read['name'], 'content': 'poopy'}),
+            headers=self.headers_json_user3,
         )
         self.assertEqual(response.status_code, 404)
         data = json.loads(response.data.decode('utf-8'))
@@ -324,7 +334,6 @@ class NotesTestCase(unittest.TestCase):
         # OK
         response = self.client.delete(f'/notes/{note_id}', headers=self.headers_json_user1)
         self.assertEqual(response.status_code, 200)
-
 
     def test_change_note_owner(self):
         response = self.client.post('/notes', data=json.dumps(self.note_read), headers=self.headers_json_user1)
@@ -437,7 +446,6 @@ class NotesTestCase(unittest.TestCase):
             f'/notes/{note_id}/owner', data=json.dumps({'owner': str(self.user2.id)}), headers=self.headers_json_user3
         )
         self.assertEqual(response.status_code, 404)
-
 
     def test_change_note_owner_delete(self):
         response = self.client.post('/notes', data=json.dumps(self.note_delete), headers=self.headers_json_user1)

--- a/tests/test_note_permissions.py
+++ b/tests/test_note_permissions.py
@@ -1,0 +1,181 @@
+import json
+import unittest
+from uuid import uuid4
+
+from turplanlegger.app import create_app, db
+from turplanlegger.auth.utils import hash_password
+from turplanlegger.models.user import User
+
+
+class NotesTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        config = {
+            'TESTING': True,
+            'SECRET_KEY': 'test',
+            'SECRET_KEY_ID': 'test',
+            'LOG_LEVEL': 'INFO',
+            'CREATE_ADMIN_USER': True,
+        }
+
+        cls.app = create_app(config)
+        cls.client = cls.app.test_client()
+
+        cls.user1 = User.create(
+            User(
+                id=str(uuid4()),
+                name='Ola',
+                last_name='Nordamnn',
+                email='old.nordmann@norge.no',
+                auth_method='basic',
+                password=hash_password('test'),
+            )
+        )
+        cls.user2 = User.create(
+            User(
+                id=str(uuid4()),
+                name='Kari',
+                last_name='Nordamnn',
+                email='kari.nordmann@norge.no',
+                auth_method='basic',
+                password=hash_password('test'),
+            )
+        )
+        cls.user3 = User.create(
+            User(
+                name='Bård',
+                last_name='Nordamnn',
+                email='baard.nordmann@norge.no',
+                auth_method='basic',
+                password=hash_password('test'),
+            )
+        )
+
+        cls.note_no_content = {
+            'name': 'Best note ever',
+        }
+        cls.note_read = {
+            'name': 'Notin pete read perms',
+            'content': 'Wait a minute, these notes have permissions with them',
+            'permissions': [
+                {
+                    'subject_id': str(cls.user2.id),
+                    'access_level': 'READ',
+                },
+            ],
+        }
+        cls.note_modify = {
+            'name': 'Notin pete modify perms',
+            'content': 'Wait a minute, these notes have more permissions with them',
+            'permissions': [
+                {
+                    'subject_id': str(cls.user2.id),
+                    'access_level': 'MODIFY',
+                },
+            ],
+        }
+        cls.note_delete = {
+            'name': 'Notin pete modify perms',
+            'content': 'Wait a minute, these notes have even more permissions with them',
+            'permissions': [
+                {
+                    'subject_id': str(cls.user2.id),
+                    'access_level': 'DELETE',
+                },
+            ],
+        }
+
+
+        # User 1
+        response = cls.client.post(
+            '/login',
+            data=json.dumps({'email': cls.user1.email, 'password': 'test'}),
+            headers={'Content-type': 'application/json'},
+        )
+
+        if response.status_code != 200:
+            raise RuntimeError('Failed to login user 1')
+
+        data = json.loads(response.data.decode('utf-8'))
+
+        cls.headers_json_user1 = {'Content-type': 'application/json', 'Authorization': f'Bearer {data["token"]}'}
+        cls.headers_user1 = {'Authorization': f'Bearer {data["token"]}'}
+
+        # User 2
+        response = cls.client.post(
+            '/login',
+            data=json.dumps({'email': cls.user2.email, 'password': 'test'}),
+            headers={'Content-type': 'application/json'},
+        )
+
+        if response.status_code != 200:
+            raise RuntimeError('Failed to login user 2')
+
+        data = json.loads(response.data.decode('utf-8'))
+
+        cls.headers_json_user2 = {'Content-type': 'application/json', 'Authorization': f'Bearer {data["token"]}'}
+        cls.headers_user2 = {'Authorization': f'Bearer {data["token"]}'}
+
+        # User 3
+        response = cls.client.post(
+            '/login',
+            data=json.dumps({'email': cls.user3.email, 'password': 'test'}),
+            headers={'Content-type': 'application/json'},
+        )
+
+        if response.status_code != 200:
+            raise RuntimeError('Failed to login user 3')
+
+        data = json.loads(response.data.decode('utf-8'))
+
+        cls.headers_json_user3 = {'Content-type': 'application/json', 'Authorization': f'Bearer {data["token"]}'}
+        cls.headers_user3 = {'Authorization': f'Bearer {data["token"]}'}
+
+    def tearDown(self):
+        db.truncate_table('notes')
+        db.truncate_table('note_permissions')
+
+    @classmethod
+    def tearDownClass(cls):
+        db.destroy()
+
+    def test_add_note_ok(self):
+        response = self.client.post('/notes', data=json.dumps(self.note_read), headers=self.headers_json_user1)
+        self.assertEqual(response.status_code, 201)
+
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['owner'], str(self.user1.id))
+        self.assertEqual(data['content'], self.note_read['content'])
+        self.assertEqual(data['name'], self.note_read['name'])
+        self.assertEqual(len(data['permissions']), 1)
+        self.assertEqual(data['permissions'][0]['access_level'], 'READ')
+        self.assertEqual(data['permissions'][0]['object_id'], data['id'])
+        self.assertEqual(data['permissions'][0]['subject_id'], str(self.user2.id))
+
+    def test_get_note(self):
+        response = self.client.post('/notes', data=json.dumps(self.note_read), headers=self.headers_json_user1)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        note_id = data['id']
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(data['permissions']), 1)
+        self.assertEqual(data['permissions'][0]['subject_id'], str(self.user2.id))
+
+        # User 2 - ok
+        response = self.client.get(f'/notes/{note_id}', headers=self.headers_user2)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+
+        self.assertEqual(len(data['note']['permissions']), 1)
+        self.assertEqual(data['note']['permissions'][0]['subject_id'], str(self.user2.id))
+
+        # User 3 - not ok
+        response = self.client.get(f'/notes/{note_id}', headers=self.headers_user3)
+        self.assertEqual(response.status_code, 404)
+        data = json.loads(response.data.decode('utf-8'))
+
+        self.assertEqual(data['title'], 'Note not found')
+        self.assertEqual(data['detail'], 'The requested note was not found')
+        self.assertEqual(data['type'], 'about:blank')
+        self.assertEqual(data['instance'], f'http://localhost/notes/{note_id}')

--- a/tests/test_note_permissions.py
+++ b/tests/test_note_permissions.py
@@ -511,8 +511,17 @@ class NotesTestCase(unittest.TestCase):
         # Not ok
         response = self.client.patch(
             f'/notes/{note_id}/permissions',
-            data=json.dumps({'permissions': [{'subject_id': str(self.user3.id),'access_level': 'READ',},]}),
-            headers=self.headers_json_user2
+            data=json.dumps(
+                {
+                    'permissions': [
+                        {
+                            'subject_id': str(self.user3.id),
+                            'access_level': 'READ',
+                        },
+                    ]
+                }
+            ),
+            headers=self.headers_json_user2,
         )
 
         self.assertEqual(response.status_code, 403)
@@ -546,8 +555,17 @@ class NotesTestCase(unittest.TestCase):
         # Ok
         response = self.client.patch(
             f'/notes/{note_id}/permissions',
-            data=json.dumps({'permissions': [{'subject_id': str(self.user3.id),'access_level': 'READ',},]}),
-            headers=self.headers_json_user1
+            data=json.dumps(
+                {
+                    'permissions': [
+                        {
+                            'subject_id': str(self.user3.id),
+                            'access_level': 'READ',
+                        },
+                    ]
+                }
+            ),
+            headers=self.headers_json_user1,
         )
 
         self.assertEqual(response.status_code, 200)
@@ -580,8 +598,17 @@ class NotesTestCase(unittest.TestCase):
         # Not ok
         response = self.client.patch(
             f'/notes/{note_id}/permissions',
-            data=json.dumps({'permissions': [{'subject_id': str(self.user2.id),'access_level': 'READ',},]}),
-            headers=self.headers_json_user1
+            data=json.dumps(
+                {
+                    'permissions': [
+                        {
+                            'subject_id': str(self.user2.id),
+                            'access_level': 'READ',
+                        },
+                    ]
+                }
+            ),
+            headers=self.headers_json_user1,
         )
 
         self.assertEqual(response.status_code, 409)

--- a/turplanlegger/database/base.py
+++ b/turplanlegger/database/base.py
@@ -271,7 +271,7 @@ class Database:
         return self._updateone(update, {'id': id, 'owner': owner}, returning=True)
 
     # Note
-    def get_note(self, id: int, deleted: bool=False):
+    def get_note(self, id: int, deleted: bool = False):
         select = """
             SELECT * FROM notes WHERE id = %s
         """

--- a/turplanlegger/database/base.py
+++ b/turplanlegger/database/base.py
@@ -88,6 +88,7 @@ class Database:
                 'users',
                 'routes',
                 'notes',
+                'note_permissions',
                 'trip_permissions',
                 'trips_notes_references',
                 'trips_routes_references',
@@ -346,6 +347,24 @@ class Database:
             RETURNING *
         """
         return self._updateone(update, {'id': id, 'content': content}, returning=True)
+
+    # Note permissions
+    def get_note_subject_permissions(self, note_id: int, owner_id: UUID):
+        select = 'SELECT access_level FROM note_permissions WHERE trip_id =%(note_id)s AND user_id = %(owner_id)s'
+        return self._fetchone(select, {'object_id': note_id, 'owner_id': owner_id})
+
+    def get_note_all_permissions(self, note_id: int):
+        "Select all note permissions based on note id"
+        select = 'SELECT object_id, access_level, subject_id FROM note_permissions WHERE object_id= %s'
+        return self._fetchall(select, (note_id,))
+
+    def create_note_permissions(self, note_permission):
+        insert_note_permission = """
+            INSERT INTO note_permissions (object_id, subject_id, access_level)
+            VALUES (%(object_id)s, %(subject_id)s, %(access_level)s)
+            RETURNING *
+        """
+        return self._insert(insert_note_permission, vars(note_permission))
 
     # User
     def get_user(self, id, deleted=False):

--- a/turplanlegger/database/base.py
+++ b/turplanlegger/database/base.py
@@ -271,7 +271,7 @@ class Database:
         return self._updateone(update, {'id': id, 'owner': owner}, returning=True)
 
     # Note
-    def get_note(self, id, deleted=False):
+    def get_note(self, id: int, deleted: bool=False):
         select = """
             SELECT * FROM notes WHERE id = %s
         """

--- a/turplanlegger/database/base.py
+++ b/turplanlegger/database/base.py
@@ -299,14 +299,14 @@ class Database:
         return self._insert(insert, vars(note))
 
     def update_note(self, note):
-        update = 'UPDATE notes SET update_time=CURRENT_TIMESTAMP'
-        if note.name is None:
-            update += ', name=NULL'
-        else:
-            update += ', name=%(name)s'
-
-        update += ', content=%(content)s WHERE id=%(id)s RETURNING *'
-        return self._updateone(update, vars(note), returning=True)
+        update = """
+            UPDATE notes SET
+                update_time=CURRENT_TIMESTAMP,
+                name=%(name)s, content=%(content)s
+                WHERE id = %(id)s
+            RETURNING *
+        """
+        return self._updateone(update, {'name': note.name, 'content': note.content, 'id': note.id }, returning=True)
 
     def delete_note(self, id):
         update = """

--- a/turplanlegger/database/base.py
+++ b/turplanlegger/database/base.py
@@ -306,7 +306,7 @@ class Database:
                 WHERE id = %(id)s
             RETURNING *
         """
-        return self._updateone(update, {'name': note.name, 'content': note.content, 'id': note.id }, returning=True)
+        return self._updateone(update, {'name': note.name, 'content': note.content, 'id': note.id}, returning=True)
 
     def delete_note(self, id):
         update = """

--- a/turplanlegger/database/base.py
+++ b/turplanlegger/database/base.py
@@ -499,16 +499,16 @@ class Database:
 
     # Trip permissions
     def get_trip_subject_permissions(self, trip_id: int, owner_id: UUID):
-        select = 'SELECT access_level FROM trip_permissions WHERE trip_id =%(trip_id)s AND user_id = %(owner_id)s'
-        return self._fetchone(select, {'trip_id': trip_id, 'owner_id': owner_id})
+        select = 'SELECT access_level FROM trip_permissions WHERE object_id=%(trip_id)s AND user_id = %(owner_id)s'
+        return self._fetchone(select, {'object_id': trip_id, 'owner_id': owner_id})
 
     def get_trip_all_permissions(self, trip_id: int):
-        select = 'SELECT trip_id, access_level, subject_id FROM trip_permissions WHERE trip_id =%s'
+        select = 'SELECT object_id, access_level, subject_id FROM trip_permissions WHERE object_id = %s'
         return self._fetchall(select, (trip_id,))
 
     def create_trip_permissions(self, trip_permission):
         insert_trip_permission = """
-            INSERT INTO trip_permissions (trip_id, subject_id, access_level)
+            INSERT INTO trip_permissions (object_id, subject_id, access_level)
             VALUES (%(object_id)s, %(subject_id)s, %(access_level)s)
             RETURNING *
         """

--- a/turplanlegger/database/base.py
+++ b/turplanlegger/database/base.py
@@ -298,18 +298,14 @@ class Database:
         """
         return self._insert(insert, vars(note))
 
-    def update_note(self, note, updated_fields=None):
+    def update_note(self, note):
         update = 'UPDATE notes SET update_time=CURRENT_TIMESTAMP'
-        if 'name' in updated_fields:
-            if note.name is None:
-                update += ', name=NULL'
-            else:
-                update += ', name=%(name)s'
+        if note.name is None:
+            update += ', name=NULL'
+        else:
+            update += ', name=%(name)s'
 
-        if 'content' in updated_fields:
-            update += ', content=%(content)s'
-
-        update += ' WHERE id=%(id)s RETURNING *'
+        update += ', content=%(content)s WHERE id=%(id)s RETURNING *'
         return self._updateone(update, vars(note), returning=True)
 
     def delete_note(self, id):

--- a/turplanlegger/database/base.py
+++ b/turplanlegger/database/base.py
@@ -351,7 +351,7 @@ class Database:
 
     def get_note_all_permissions(self, note_id: int):
         "Select all note permissions based on note id"
-        select = 'SELECT object_id, access_level, subject_id FROM note_permissions WHERE object_id= %s'
+        select = 'SELECT object_id, access_level, subject_id FROM note_permissions WHERE object_id = %s'
         return self._fetchall(select, (note_id,))
 
     def create_note_permissions(self, note_permission):
@@ -361,6 +361,11 @@ class Database:
             RETURNING *
         """
         return self._insert(insert_note_permission, vars(note_permission))
+
+    def delete_note_permissions(self, object_id: int, subject_id: UUID):
+        """Delete permission by primary key"""
+        del_perms = 'DELETE FROM note_permissions WHERE object_id = %(object_id)s AND subject_id = %(subject_id)s'
+        return self._deleteone(del_perms, {'object_id': object_id, 'subject_id': subject_id})
 
     # User
     def get_user(self, id, deleted=False):
@@ -656,7 +661,7 @@ class Database:
         """
         Delete, with optional return.
         """
-        self._log('_updateone', query, vars)
+        self._log('_deleteone', query, vars)
         with self.conn.transaction():
             self.cur.execute(query, vars)
             return self.cur.fetchone() if returning else None

--- a/turplanlegger/database/base.py
+++ b/turplanlegger/database/base.py
@@ -367,6 +367,16 @@ class Database:
         del_perms = 'DELETE FROM note_permissions WHERE object_id = %(object_id)s AND subject_id = %(subject_id)s'
         return self._deleteone(del_perms, {'object_id': object_id, 'subject_id': subject_id})
 
+    def update_note_permission(self, note_permission):
+        """Update permission"""
+        update = """
+            UPDATE note_permissions
+                SET access_level = %(access_level)s
+                WHERE object_id = %(object_id)s AND subject_id = %(subject_id)s
+            RETURNING *
+        """
+        return self._updateone(update, vars(note_permission), returning=True)
+
     # User
     def get_user(self, id, deleted=False):
         select = 'SELECT * FROM users WHERE id = %s::UUID'

--- a/turplanlegger/database/schema.sql
+++ b/turplanlegger/database/schema.sql
@@ -74,10 +74,10 @@ CREATE TABLE IF NOT EXISTS trips (
 );
 
 CREATE TABLE IF NOT EXISTS trip_permissions (
-    trip_id int NOT NULL REFERENCES trips (id) ON DELETE CASCADE,
+    object_id int NOT NULL REFERENCES trips (id) ON DELETE CASCADE,
     subject_id UUID NOT NULL REFERENCES users (id),
     access_level access_level NOT NULL,
-    PRIMARY KEY (trip_id, subject_id)
+    PRIMARY KEY (object_id, subject_id)
 );
 
 CREATE TABLE IF NOT EXISTS trip_dates (

--- a/turplanlegger/database/schema.sql
+++ b/turplanlegger/database/schema.sql
@@ -62,6 +62,13 @@ CREATE TABLE IF NOT EXISTS notes (
     delete_time timestamp without time zone
 );
 
+CREATE TABLE IF NOT EXISTS note_permissions (
+    object_id int NOT NULL REFERENCES notes (id) ON DELETE CASCADE,
+    subject_id UUID NOT NULL REFERENCES users (id),
+    access_level access_level NOT NULL,
+    PRIMARY KEY (object_id, subject_id)
+);
+
 CREATE TABLE IF NOT EXISTS trips (
     id serial PRIMARY KEY,
     name text NOT NULL,

--- a/turplanlegger/models/note.py
+++ b/turplanlegger/models/note.py
@@ -120,6 +120,9 @@ class Note:
 
         return Note.get_note(db.change_note_owner(self.id, owner))
 
+    def add_permissions(self, permissions: tuple[Permission]) -> tuple[Permission]:
+        return tuple(perm.create_note() for perm in permissions)
+
     @classmethod
     def get_note(cls, rec) -> 'Note':
         if rec is None:

--- a/turplanlegger/models/note.py
+++ b/turplanlegger/models/note.py
@@ -91,11 +91,11 @@ class Note:
             for permission in self.permissions:
                 permission.object_id = note.id
                 permissions.append(permission.create_note())
-        note.permissions = permissions
+            note.permissions = permissions
         return note
 
-    def update(self, updated_fields) -> 'Note':
-        return db.update_note(self, updated_fields)
+    def update(self) -> 'Note':
+        return db.update_note(self)
 
     def delete(self) -> bool:
         return db.delete_note(self.id)

--- a/turplanlegger/models/note.py
+++ b/turplanlegger/models/note.py
@@ -95,7 +95,7 @@ class Note:
         return note
 
     def update(self) -> 'Note':
-        return db.update_note(self)
+        return Note.get_note(db.update_note(self))
 
     def delete(self) -> bool:
         return db.delete_note(self.id)

--- a/turplanlegger/models/note.py
+++ b/turplanlegger/models/note.py
@@ -120,8 +120,13 @@ class Note:
 
         return Note.get_note(db.change_note_owner(self.id, owner))
 
-    def add_permissions(self, permissions: tuple[Permission]) -> tuple[Permission]:
+    @staticmethod
+    def add_permissions(permissions: tuple[Permission]) -> tuple[Permission]:
         return tuple(perm.create_note() for perm in permissions)
+
+    @staticmethod
+    def delete_permission(permission: Permission) -> None:
+        return permission.delete_note()
 
     @classmethod
     def get_note(cls, rec) -> 'Note':

--- a/turplanlegger/models/note.py
+++ b/turplanlegger/models/note.py
@@ -128,6 +128,10 @@ class Note:
     def delete_permission(permission: Permission) -> None:
         return permission.delete_note()
 
+    @staticmethod
+    def update_permission(permission: Permission) -> None:
+        return permission.update_note()
+
     @classmethod
     def get_note(cls, rec) -> 'Note':
         if rec is None:

--- a/turplanlegger/models/note.py
+++ b/turplanlegger/models/note.py
@@ -28,6 +28,7 @@ class Note:
         deleted (bool): Flag indicating if the note has been deleted
         delete_time (datetime): Time the note was deleted
     """
+
     def __init__(self, owner: UUID, content: str, **kwargs) -> None:
         if not owner:
             raise ValueError("Missing mandatory field 'owner'")
@@ -59,7 +60,6 @@ class Note:
 
     @classmethod
     def parse(cls, json: JSON) -> 'Note':
-
         permissions = json.get('permissions', [])
         if not isinstance(permissions, list):
             raise TypeError('permissions has to be a list of permission objects')
@@ -70,7 +70,7 @@ class Note:
             owner=g.user.id,
             content=json.get('content', None),
             name=json.get('name', None),
-            permissions=permissions
+            permissions=permissions,
         )
 
     @property

--- a/turplanlegger/models/note.py
+++ b/turplanlegger/models/note.py
@@ -52,7 +52,7 @@ class Note:
         return (
             f"Note(id='{self.id}', owner='{self.owner}', "
             f"name='{self.name}', content='{self.content}', "
-            f'permission={self.permissions}), '
+            f'permissions={self.permissions}), '
             f'create_time={self.create_time}, update_time={self.update_time}, '
             f'deleted={self.deleted}, delete_time={self.delete_time})'
         )

--- a/turplanlegger/models/permission.py
+++ b/turplanlegger/models/permission.py
@@ -51,8 +51,9 @@ class Permission:
     def find_trip_user_permissions(trip_id: int, user_id: UUID) -> 'Permission':
         return Permission.get_permission(db.get_trip_permissions(trip_id, user_id))
 
-    def create(self) -> 'Permission':
-        """Creates the Permission instance in the database"""
+
+    def create_trip(self) -> 'Permission':
+        """Creates a trip Permission instance in the database"""
         return self.get_permission(db.create_trip_permissions(self))
 
     @classmethod
@@ -68,4 +69,4 @@ class Permission:
         if rec is None:
             return None
 
-        return Permission(object_id=rec.trip_id, subject_id=rec.subject_id, access_level=rec.access_level)
+        return Permission(object_id=rec.object_id, subject_id=rec.subject_id, access_level=rec.access_level)

--- a/turplanlegger/models/permission.py
+++ b/turplanlegger/models/permission.py
@@ -34,7 +34,7 @@ class Permission:
 
         return Permission(
             object_id=json.get('object_id', None),
-            subject_id=json.get('subject_id', None),
+            subject_id=UUID(json.get('subject_id', None)),
             access_level=AccessLevel(json.get('access_level', None)),
         )
 

--- a/turplanlegger/models/permission.py
+++ b/turplanlegger/models/permission.py
@@ -77,7 +77,7 @@ class Permission:
                 return PermissionResult.ALLOWED
             # If subject has read but not more
             elif any(
-                perm.subject_id == subject_id and perm.access_level == AccessLevel.READ for perm in permissions
+                perm.subject_id == subject_id and perm.access_level >= AccessLevel.READ for perm in permissions
             ):
                 return PermissionResult.INSUFFICIENT_PERMISSIONS
             else:

--- a/turplanlegger/models/permission.py
+++ b/turplanlegger/models/permission.py
@@ -33,7 +33,7 @@ class Permission:
         """
 
         return Permission(
-            object_id=json.get('id', None),
+            object_id=json.get('object_id', None),
             subject_id=json.get('subject_id', None),
             access_level=AccessLevel(json.get('access_level', None)),
         )

--- a/turplanlegger/models/permission.py
+++ b/turplanlegger/models/permission.py
@@ -102,6 +102,10 @@ class Permission:
         """Removes a note Permission instance in the database"""
         return self.get_permission(db.delete_note_permissions(self.object_id, self.subject_id))
 
+    def update_note(self) -> None:
+        """Updates a note Permission instance in the database"""
+        return self.get_permission(db.update_note_permission(self))
+
     def create_trip(self) -> 'Permission':
         """Creates a trip Permission instance in the database"""
         return self.get_permission(db.create_trip_permissions(self))

--- a/turplanlegger/models/permission.py
+++ b/turplanlegger/models/permission.py
@@ -43,9 +43,10 @@ class Permission:
         """Serialize the Permission instance and returns it as Dict(str, any)"""
         return {'object_id': self.object_id, 'subject_id': self.subject_id, 'access_level': self.access_level}
 
-
     @staticmethod
-    def verify(owner: UUID, permissions: list['Permission'], subject_id: UUID, required_level: AccessLevel) -> PermissionResult:
+    def verify(
+        owner: UUID, permissions: list['Permission'], subject_id: UUID, required_level: AccessLevel
+    ) -> PermissionResult:
         """Verify permissions on a trip
 
         Args:
@@ -66,9 +67,7 @@ class Permission:
         if required_level == AccessLevel.READ:
             return (
                 PermissionResult.ALLOWED
-                if any(
-                    perm.subject_id == subject_id and perm.access_level >= AccessLevel.READ for perm in permissions
-                )
+                if any(perm.subject_id == subject_id and perm.access_level >= AccessLevel.READ for perm in permissions)
                 else PermissionResult.NOT_FOUND
             )
         else:
@@ -76,9 +75,7 @@ class Permission:
             if any(perm.subject_id == subject_id and perm.access_level >= required_level for perm in permissions):
                 return PermissionResult.ALLOWED
             # If subject has read but not more
-            elif any(
-                perm.subject_id == subject_id and perm.access_level >= AccessLevel.READ for perm in permissions
-            ):
+            elif any(perm.subject_id == subject_id and perm.access_level >= AccessLevel.READ for perm in permissions):
                 return PermissionResult.INSUFFICIENT_PERMISSIONS
             else:
                 return PermissionResult.NOT_FOUND

--- a/turplanlegger/models/permission.py
+++ b/turplanlegger/models/permission.py
@@ -98,6 +98,10 @@ class Permission:
         """Creates a note Permission instance in the database"""
         return self.get_permission(db.create_note_permissions(self))
 
+    def delete_note(self) -> None:
+        """Removes a note Permission instance in the database"""
+        return self.get_permission(db.delete_note_permissions(self.object_id, self.subject_id))
+
     def create_trip(self) -> 'Permission':
         """Creates a trip Permission instance in the database"""
         return self.get_permission(db.create_trip_permissions(self))

--- a/turplanlegger/models/permission.py
+++ b/turplanlegger/models/permission.py
@@ -83,6 +83,11 @@ class Permission:
             else:
                 return PermissionResult.NOT_FOUND
 
+    # Note
+    @staticmethod
+    def find_note_all_permissions(note_id: int) -> 'Permission':
+        return [Permission.get_permission(permission) for permission in db.get_note_all_permissions(note_id)]
+
     # Trip
     @staticmethod
     def find_trip_all_permissions(trip_id: int) -> 'Permission':
@@ -92,6 +97,9 @@ class Permission:
     def find_trip_user_permissions(trip_id: int, user_id: UUID) -> 'Permission':
         return Permission.get_permission(db.get_trip_permissions(trip_id, user_id))
 
+    def create_note(self) -> 'Permission':
+        """Creates a note Permission instance in the database"""
+        return self.get_permission(db.create_note_permissions(self))
 
     def create_trip(self) -> 'Permission':
         """Creates a trip Permission instance in the database"""

--- a/turplanlegger/models/trip.py
+++ b/turplanlegger/models/trip.py
@@ -133,7 +133,7 @@ class Trip:
             permissions = []
             for permission in self.permissions:
                 permission.object_id = trip.id
-                permissions.append(permission.create())
+                permissions.append(permission.create_trip())
             trip.permissions = permissions
         return trip
 

--- a/turplanlegger/views/notes.py
+++ b/turplanlegger/views/notes.py
@@ -2,7 +2,9 @@ from flask import g, jsonify, request
 
 from turplanlegger.auth.decorators import auth
 from turplanlegger.exceptions import ApiProblem
+from turplanlegger.models.access_level import AccessLevel
 from turplanlegger.models.note import Note
+from turplanlegger.models.permission import Permission, PermissionResult
 
 from . import api
 
@@ -12,7 +14,7 @@ from . import api
 def get_note(note_id):
     note = Note.find_note(note_id)
 
-    if note:
+    if note and Permission.verify(note.owner, note.permissions, g.user.id, AccessLevel.READ) is PermissionResult.ALLOWED:
         return jsonify(status='ok', count=1, note=note.serialize)
     else:
         raise ApiProblem('Note not found', 'The requested note was not found', 404)

--- a/turplanlegger/views/notes.py
+++ b/turplanlegger/views/notes.py
@@ -124,6 +124,9 @@ def change_note_owner(note_id):
 @api.route('/notes/<note_id>/rename', methods=['PATCH'])
 @auth
 def rename_note(note_id):
+
+    raise ApiProblem('Endpoint has been deprecated', 'Use PUT /notes/<note_id> instead', 410)
+
     note = Note.find_note(note_id)
 
     if not note:

--- a/turplanlegger/views/notes.py
+++ b/turplanlegger/views/notes.py
@@ -148,6 +148,7 @@ def get_my_notes():
     else:
         raise ApiProblem('Note not found', 'No notes were found for the requested user', 404)
 
+
 @api.route('/notes/<note_id>/permissions', methods=['PATCH'])
 @auth
 def add_permissions(note_id):
@@ -165,11 +166,7 @@ def add_permissions(note_id):
     permissions_input = request.json.get('permissions', [])
 
     if not isinstance(permissions_input, list) or not permissions_input:
-        raise ApiProblem(
-            'Bad Request',
-            'You must supply a non‐empty "permissions" array',
-            400
-        )
+        raise ApiProblem('Bad Request', 'You must supply a non‐empty "permissions" array', 400)
 
     new_permissions = []
     for perm in permissions_input:
@@ -182,7 +179,7 @@ def add_permissions(note_id):
 
     try:
         permissions = tuple(Permission.parse(permission) for permission in new_permissions)
-    except ValueError as e:
+    except ValueError:
         raise ApiProblem('Failed to add new permissions', 'No new permissions were parsed', 400)
 
     for perm in permissions:

--- a/turplanlegger/views/notes.py
+++ b/turplanlegger/views/notes.py
@@ -185,6 +185,10 @@ def add_permissions(note_id):
     except ValueError as e:
         raise ApiProblem('Failed to add new permissions', 'No new permissions were parsed', 400)
 
+    for perm in permissions:
+        if perm in note.permissions:
+            raise ApiProblem('Failed to add permissions', 'The permission already exists', 409)
+
     try:
         new_permissions = note.add_permissions(permissions)
     except ValueError as e:

--- a/turplanlegger/views/notes.py
+++ b/turplanlegger/views/notes.py
@@ -99,6 +99,13 @@ def change_note_owner(note_id):
     if not note:
         raise ApiProblem('Note not found', 'The requested note was not found', 404)
 
+    perms = Permission.verify(note.owner, note.permissions, g.user.id, AccessLevel.READ)
+    if perms is PermissionResult.NOT_FOUND:
+        raise ApiProblem('Note not found', 'The requested note was not found', 404)
+    
+    if note.owner != g.user.id:
+        raise ApiProblem('Insufficient permissions', 'Not sufficient permissions to change owner the note', 403)
+
     owner = request.json.get('owner', None)
 
     if not owner:

--- a/turplanlegger/views/notes.py
+++ b/turplanlegger/views/notes.py
@@ -133,6 +133,9 @@ def rename_note(note_id):
 @api.route('/notes/<note_id>/content', methods=['PATCH'])
 @auth
 def update_note_content(note_id):
+
+    raise ApiProblem('Endpoint has been deprecated', 'Use PUT /notes/<note_id> instead', 410)
+
     note = Note.find_note(note_id)
 
     if not note:

--- a/turplanlegger/views/notes.py
+++ b/turplanlegger/views/notes.py
@@ -1,3 +1,4 @@
+from IPython import embed
 from flask import g, jsonify, request
 
 from turplanlegger.auth.decorators import auth
@@ -27,6 +28,12 @@ def delete_note(note_id):
 
     if note is None:
         raise ApiProblem('Note not found', 'The requested note was not found', 404)
+
+    perms = Permission.verify(note.owner, note.permissions, g.user.id, AccessLevel.DELETE)
+    if perms is PermissionResult.NOT_FOUND:
+        raise ApiProblem('Note not found', 'The requested note was not found', 404)
+    if perms is PermissionResult.INSUFFICIENT_PERMISSIONS:
+        raise ApiProblem('Insufficient permissions', 'Not sufficient permissions to delete the note', 403)
 
     try:
         note.delete()

--- a/turplanlegger/views/notes.py
+++ b/turplanlegger/views/notes.py
@@ -122,41 +122,13 @@ def change_note_owner(note_id):
 
 
 @api.route('/notes/<note_id>/rename', methods=['PATCH'])
-@auth
 def rename_note(note_id):
-
     raise ApiProblem('Endpoint has been deprecated', 'Use PUT /notes/<note_id> instead', 410)
-
-    note = Note.find_note(note_id)
-
-    if not note:
-        raise ApiProblem('Note not found', 'The requested note was not found', 404)
-
-    note.name = request.json.get('name', '')
-
-    if note.rename():
-        return jsonify(status='ok')
-    else:
-        raise ApiProblem('Failed to rename note', 'Unknown error', 500)
 
 
 @api.route('/notes/<note_id>/content', methods=['PATCH'])
-@auth
 def update_note_content(note_id):
-
     raise ApiProblem('Endpoint has been deprecated', 'Use PUT /notes/<note_id> instead', 410)
-
-    note = Note.find_note(note_id)
-
-    if not note:
-        raise ApiProblem('Note not found', 'The requested note was not found', 404)
-
-    note.content = request.json.get('content', '')
-
-    if note.update_content():
-        return jsonify(status='ok')
-    else:
-        raise ApiProblem('Failed to update note', 'Unknown error', 500)
 
 
 @api.route('/notes/mine', methods=['GET'])

--- a/turplanlegger/views/notes.py
+++ b/turplanlegger/views/notes.py
@@ -1,4 +1,3 @@
-from IPython import embed
 from flask import g, jsonify, request
 
 from turplanlegger.auth.decorators import auth
@@ -15,7 +14,10 @@ from . import api
 def get_note(note_id):
     note = Note.find_note(note_id)
 
-    if note and Permission.verify(note.owner, note.permissions, g.user.id, AccessLevel.READ) is PermissionResult.ALLOWED:
+    if (
+        note
+        and Permission.verify(note.owner, note.permissions, g.user.id, AccessLevel.READ) is PermissionResult.ALLOWED
+    ):
         return jsonify(status='ok', count=1, note=note.serialize)
     else:
         raise ApiProblem('Note not found', 'The requested note was not found', 404)
@@ -102,7 +104,7 @@ def change_note_owner(note_id):
     perms = Permission.verify(note.owner, note.permissions, g.user.id, AccessLevel.READ)
     if perms is PermissionResult.NOT_FOUND:
         raise ApiProblem('Note not found', 'The requested note was not found', 404)
-    
+
     if note.owner != g.user.id:
         raise ApiProblem('Insufficient permissions', 'Not sufficient permissions to change owner the note', 403)
 

--- a/turplanlegger/views/trips.py
+++ b/turplanlegger/views/trips.py
@@ -5,7 +5,7 @@ from turplanlegger.exceptions import ApiProblem
 from turplanlegger.models.access_level import AccessLevel
 from turplanlegger.models.item_lists import ItemList
 from turplanlegger.models.note import Note
-from turplanlegger.models.permission import PermissionResult
+from turplanlegger.models.permission import PermissionResult, Permission
 from turplanlegger.models.route import Route
 from turplanlegger.models.trip import Trip
 from turplanlegger.models.trip_date import TripDate
@@ -17,7 +17,7 @@ from . import api
 @auth
 def get_trip(trip_id):
     trip = Trip.find_trip(trip_id)
-    if trip and trip.verify_permissions(g.user.id, AccessLevel.READ) is PermissionResult.ALLOWED:
+    if trip and Permission.verify(trip.owner, trip.permissions, g.user.id, AccessLevel.READ) is PermissionResult.ALLOWED:
         return jsonify(status='ok', count=1, trip=trip.serialize)
     else:
         raise ApiProblem('Trip not found', 'The requested trip was not found', 404)
@@ -46,7 +46,7 @@ def update_trip(trip_id):
     if not trip:
         raise ApiProblem('Trip not found', 'The requested trip was not found', 404)
 
-    perms = trip.verify_permissions(g.user.id, AccessLevel.MODIFY)
+    perms = Permission.verify(trip.owner, trip.permissions, g.user.id, AccessLevel.MODIFY)
     if perms is PermissionResult.NOT_FOUND:
         raise ApiProblem('Trip not found', 'The requested trip was not found', 404)
     if perms is PermissionResult.INSUFFICIENT_PERMISSIONS:
@@ -185,7 +185,7 @@ def get_my_trips():
 @auth
 def delete_trip(trip_id):
     trip = Trip.find_trip(trip_id)
-    if not trip or trip.verify_permissions(g.user.id, AccessLevel.DELETE) is PermissionResult.NOT_FOUND:
+    if not trip or Permission.verify(trip.owner, trip.permissions, g.user.id, AccessLevel.DELETE) is PermissionResult.NOT_FOUND:
         raise ApiProblem('Trip not found', 'The requested trip was not found', 404)
 
     try:
@@ -225,7 +225,7 @@ def remove_trip_date(trip_id, trip_date_id):
     if not trip:
         raise ApiProblem('Failed to remove date from trip', 'The requested trip was not found', 404)
 
-    perms = trip.verify_permissions(g.user.id, AccessLevel.DELETE)
+    perms = Permission.verify(trip.owner, trip.permissions, g.user.id, AccessLevel.DELETE)
     if perms is PermissionResult.NOT_FOUND:
         raise ApiProblem('Trip not found', 'The requested trip was not found', 404)
     if perms is PermissionResult.INSUFFICIENT_PERMISSIONS:

--- a/turplanlegger/views/trips.py
+++ b/turplanlegger/views/trips.py
@@ -5,7 +5,7 @@ from turplanlegger.exceptions import ApiProblem
 from turplanlegger.models.access_level import AccessLevel
 from turplanlegger.models.item_lists import ItemList
 from turplanlegger.models.note import Note
-from turplanlegger.models.permission import PermissionResult, Permission
+from turplanlegger.models.permission import Permission, PermissionResult
 from turplanlegger.models.route import Route
 from turplanlegger.models.trip import Trip
 from turplanlegger.models.trip_date import TripDate
@@ -17,7 +17,10 @@ from . import api
 @auth
 def get_trip(trip_id):
     trip = Trip.find_trip(trip_id)
-    if trip and Permission.verify(trip.owner, trip.permissions, g.user.id, AccessLevel.READ) is PermissionResult.ALLOWED:
+    if (
+        trip
+        and Permission.verify(trip.owner, trip.permissions, g.user.id, AccessLevel.READ) is PermissionResult.ALLOWED
+    ):
         return jsonify(status='ok', count=1, trip=trip.serialize)
     else:
         raise ApiProblem('Trip not found', 'The requested trip was not found', 404)
@@ -185,7 +188,10 @@ def get_my_trips():
 @auth
 def delete_trip(trip_id):
     trip = Trip.find_trip(trip_id)
-    if not trip or Permission.verify(trip.owner, trip.permissions, g.user.id, AccessLevel.DELETE) is PermissionResult.NOT_FOUND:
+    if (
+        not trip
+        or Permission.verify(trip.owner, trip.permissions, g.user.id, AccessLevel.DELETE) is PermissionResult.NOT_FOUND
+    ):
         raise ApiProblem('Trip not found', 'The requested trip was not found', 404)
 
     try:


### PR DESCRIPTION
This PR aims to implement permission on all note endpoints.

Closes #353 

Added:
  - Trip permission database table
  - Permission check on all note endpoints
  - Test for all note endpoints with permissions

Changed:
  - Centralise permission verification method

Removed:
  - `PATCH` API endpoints for note content and name in favour for PUT endpoint


![note](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGF1OGNndmF0aW11b2c1cHloN2ExMzg2anczbHlwMzIxcnhkbGkwbyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/YW5Ynki0aGxFSe5Xps/giphy.gif "noted")