### PR TITLE
Fix missing quotes in pip install extras for zsh compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ pip install .
 
 ### Production
 ```bash
-pip install .[prod]
+pip install '.[prod]'
 ```
 
 ### Development
 ```bash
-pip install .[dev]
+pip install '.[dev]'
 ```
 
 ## Testing


### PR DESCRIPTION
Zsh requires quotes when using extras like `pip install .[dev]`, otherwise it attempts filename expansion and fails. This fixes the README to use `'.[dev]'` and `'.[prod]'` instead.

This new format works correctly in both zsh and bash, ensuring compatibility across different shell environments.