### PR TITLE
:safety_vest: Enforce non-blank content for notes and add validation tests

### DIFF
--- a/turplanlegger/models/note.py
+++ b/turplanlegger/models/note.py
@@ -38,6 +38,8 @@ class Note:
             raise ValueError("Missing mandatory field 'content'")
         if not isinstance(content, str):
             raise TypeError("'content' must be string")
+        if not content.strip():
+            raise ValueError("'content' must not be blank")
 
         self.owner = owner
         self.content = content


### PR DESCRIPTION
Validate note content is not blank and add tests for whitespace-only content cases.

Solves https://github.com/Turplanlegger/turplanlegger-api/issues/366