### PR TITLE
👷 Set container image tag to version from __about__.py

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Downcase repository name
         run: echo "repository=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,10 @@ jobs:
       - name: Downcase repository name
         run: echo "repository=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}
 
+      - name: Get version
+        id: get-version
+        run: echo "NEW_VERSION=$(grep -v '^#' turplanlegger/__about__.py | cut -d'=' -f2 | xargs)" >> "$GITHUB_OUTPUT"
+
       - name: Log in to the Container registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
@@ -83,9 +87,9 @@ jobs:
           context: git
           images: ${{ env.REGISTRY }}/${{ env.repository }}
           tags: |
-            type=raw,value=latest
-            type=pep440,pattern={{version}}
             type=sha,format=long
+            type=raw,value=latest
+            type=raw,value=${{ steps.get-version.outputs.NEW_VERSION }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0


### PR DESCRIPTION
When building the Docker image, use the version specified in `turplanlegger/__about__.py` as the tag instead of the default GitHub SHA. This ensures consistency between the released version and the Docker image tag.